### PR TITLE
Remove unused handler arguments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -431,7 +431,7 @@ class XZNotify extends HTMLElement implements XZNotifyProps {
   /**
    * Handler when closeable is true and clicked on the notification.
    */
-  closeHandler(e: MouseEvent | PointerEvent) {
+  closeHandler() {
     this.forcedClose = true;
   }
 


### PR DESCRIPTION
I got the following error from tsc:

<img width="933" alt="image" src="https://github.com/dknight/xz-notify/assets/16443248/3232300d-269c-481f-bb13-1877c0f11045">

In this PR, I remove the unused parameter.
The general solution to errors of this kind is to remove `ts` files from the published package in npm.

Related issue: https://github.com/microsoft/TypeScript/issues/40426